### PR TITLE
add header to TransactionOutput

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,12 @@ std = [
     'frame-benchmarking/std',
     'sp-core/std'
 ]
+test = [
+        'pallet-timestamp/std',
+        'pallet-aura/std',
+        'sp-consensus-aura/std',
+        'sp-keystore/std'
+]
 
 
 [dependencies]
@@ -29,7 +35,7 @@ frame-system = { default-features = false, version ='3.0.0' ,git = 'https://gith
 sp-core = { default-features = false, version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}
 
 [dev-dependencies]
-sp-consensus-aura = { version = "0.9.0",  git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}
-sp-keystore = { version = "0.9.0",  git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}
-pallet-aura = { version = '3.0.0',  git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}
-pallet-timestamp = { version = "3.0.0", git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}
+sp-consensus-aura = { default-features = false, version = "0.9.0",  git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}
+sp-keystore = { default-features = false,  version = "0.9.0",  git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}
+pallet-aura = { default-features = false, version = '3.0.0',  git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}
+pallet-timestamp = { default-features = false, version = "3.0.0", git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ Utxo support, based on [Substrate's workshop](https://github.com/substrate-devel
 
 This is only the pallet; no _node_ and _runtime_ implementation.
 
-To run the test cases, just run command `cargo test`.
+### How to run the test cases
+On the terminal, run `cargo test --features test`
 
 ### How to run the benchmark in [mintlayer-node](https://github.com/mintlayer/mintlayer-node):
 1. Insert this pallet-utxo crate in [pallets directory](https://github.com/mintlayer/mintlayer-node/tree/master/pallets).  


### PR DESCRIPTION
Based on the [card](https://trello.com/c/0JEY0nZX):

Added an enum `SingatureMethod` in preparation of other signature support; but default is still [BLS](https://github.com/mintlayer/pallet-utxo/compare/staging...header?expand=1#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R99)
