### PR TITLE
update header implementation:

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
-use std::convert::TryFrom;
+use sp_core::sp_std::convert::TryFrom;
 
 use codec::{Decode, Encode};
 
@@ -17,7 +17,7 @@ macro_rules! u16_to_enum {
             $($(#[$vmeta])* $vname $(= $val)?,)*
         }
 
-        impl std::convert::TryFrom<u16> for $name {
+        impl TryFrom<u16> for $name {
             type Error = &'static str;
 
             fn try_from(v: u16) -> Result<Self, Self::Error> {


### PR DESCRIPTION
update header implementation:
use macros to convert u16 to enum variant;
It'll be very tedious to when adding support of a token type or signature,
when the implementation is all but the same.
If we can avoid a lot of match typing, the better.

 `TXOutputHeaderImpls` trait to support methods dedicated for TXOutputHeader. Soon, adding header field on `TransactionOutput`