### PR TITLE
Put reward back if it cannot be split into divisions > 1 unit. Fixes #11

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,6 +187,8 @@ pub mod pallet {
             .ok_or("No authorities")
             .unwrap();
         if share_value == 0 {
+            //put reward back if it can't be split nicely
+            <RewardTotal<T>>::put(reward as Value);
             return;
         }
 


### PR DESCRIPTION
Fixes #11 where the reward was leaked if we couldn't pay the reward. We now handle it as a remainder and put the whole reward back again if the reward is less than the number of auths and we can't pay >1 unit.

Thanks to @altonen for this :+1: 